### PR TITLE
Change __callapi function

### DIFF
--- a/adobeanalytics.py
+++ b/adobeanalytics.py
@@ -41,8 +41,10 @@ class AdobeAnalytics:
         X_str = 'UsernameToken Username="%s", PasswordDigest="%s", Nonce="%s", Created="%s"' % ('%s:%s' % (self.__user_name, self.__company), password_64.strip(), base64nonce.strip(), created_date) 
         return {'X-WSSE':X_str} 
         
-    #Core Method, Actually runs the JSON request     
     def __callapi(self, endpoint, verb = "POST", **kwargs):
+        """
+        Calls the Adobe Analytics API at a given endpoint and variable arguments
+        """
         header = self.__buildheader()
         if verb == "GET":
             req = requests.get('%s?method=%s' % (self.__api_url, endpoint), params=json.dumps(kwargs), headers=header)
@@ -63,41 +65,41 @@ class AdobeAnalytics:
         """
         return self.__callapi('ReportSuite.GetActivation', rsid_list = rsid_list)
         
-    def GetAxleStartDate(self):
-        return self.__callapi('ReportSuite.GetAxleStartDate', )
+    def GetAxleStartDate(self, rsid_list):
+        return self.__callapi('ReportSuite.GetAxleStartDate', rsid_list = rsid_list)
     
-    def GetBaseCurrency(self, ):
-        return self.__callapi('ReportSuite.GetBaseCurrency', )
+    def GetBaseCurrency(self, rsid_list):
+        return self.__callapi('ReportSuite.GetBaseCurrency', rsid_list = rsid_list)
     
-    def GetBaseURL(self, ):
-        return self.__callapi('ReportSuite.GetBaseURL', )
+    def GetBaseURL(self, rsid_list):
+        return self.__callapi('ReportSuite.GetBaseURL', rsid_list = rsid_list)
     
     def GetBookmarks(self, ):
         return self.__callapi('Bookmark.GetBookmarks', )
     
-    def GetCalculatedMetrics(self, ):
-        return self.__callapi('ReportSuite.GetCalculatedMetrics', )
+    def GetCalculatedMetrics(self, rsid_list):
+        return self.__callapi('ReportSuite.GetCalculatedMetrics', rsid_list = rsid_list)
     
     def GetClassifications(self, ):
         return self.__callapi('ReportSuite.GetClassifications', )
     
-    def GetCustomCalendar(self, ):
-        return self.__callapi('ReportSuite.GetCustomCalendar', )
+    def GetCustomCalendar(self, rsid_list):
+        return self.__callapi('ReportSuite.GetCustomCalendar', rsid_list = rsid_list)
     
     def GetDashboards(self, ):
         return self.__callapi('Bookmark.GetDashboards', )
     
-    def GetDataWarehouseDisplay(self, ):
-        return self.__callapi('ReportSuite.GetDataWarehouseDisplay', )
+    def GetDataWarehouseDisplay(self, rsid_list):
+        return self.__callapi('ReportSuite.GetDataWarehouseDisplay', rsid_list = rsid_list)
     
-    def GetDefaultPage(self, ):
-        return self.__callapi('ReportSuite.GetDefaultPage', )
+    def GetDefaultPage(self, rsid_list):
+        return self.__callapi('ReportSuite.GetDefaultPage', rsid_list = rsid_list)
     
-    def GetDiscoverEnabled(self, ):
-        return self.__callapi('ReportSuite.GetDiscoverEnabled', )
+    def GetDiscoverEnabled(self, rsid_list):
+        return self.__callapi('ReportSuite.GetDiscoverEnabled', rsid_list = rsid_list)
     
-    def GetEcommerce(self, ):
-        return self.__callapi('ReportSuite.GetEcommerce', )
+    def GetEcommerce(self, rsid_list):
+        return self.__callapi('ReportSuite.GetEcommerce', rsid_list = rsid_list)
 
     def GetElements(self, ):
         return self.__callapi('Report.GetElements', )
@@ -111,8 +113,8 @@ class AdobeAnalytics:
         """ 
         return self.__callapi('Company.GetEndpoint', "GET", company = company)
     
-    def GetEvars(self, ):
-        return self.__callapi('ReportSuite.GetEvars', )
+    def GetEvars(self, rsid_list):
+        return self.__callapi('ReportSuite.GetEvars', rsid_list = rsid_list)
     
     def GetFeed(self, ):
         return self.__callapi('DataFeed.GetFeed', )
@@ -123,29 +125,29 @@ class AdobeAnalytics:
     def GetFunctions(self, ):
         return self.__callapi('CalculatedMetrics.GetFunctions', )
     
-    def GetGeoSegmentation(self, ):
-        return self.__callapi('ReportSuite.GetGeoSegmentation', )
+    def GetGeoSegmentation(self, rsid_list):
+        return self.__callapi('ReportSuite.GetGeoSegmentation', rsid_list = rsid_list)
     
     def GetGroups(self, ):
         return self.__callapi('Permissions.GetGroups', )
     
-    def GetInternalURLFilters(self, ):
-        return self.__callapi('ReportSuite.GetInternalURLFilters', )
+    def GetInternalURLFilters(self, rsid_list):
+        return self.__callapi('ReportSuite.GetInternalURLFilters', rsid_list = rsid_list)
 
-    def GetIPAddressExclusions(self, ):
-        return self.__callapi('ReportSuite.GetIPAddressExclusions', )
+    def GetIPAddressExclusions(self, rsid_list):
+        return self.__callapi('ReportSuite.GetIPAddressExclusions', rsid_list = rsid_list)
 
-    def GetIPObfuscation(self, ):
-        return self.__callapi('ReportSuite.GetIPObfuscation', )
+    def GetIPObfuscation(self, rsid_list):
+        return self.__callapi('ReportSuite.GetIPObfuscation', rsid_list = rsid_list)
     
-    def GetKeyVisitors(self, ):
-        return self.__callapi('ReportSuite.GetKeyVisitors', )
+    def GetKeyVisitors(self, rsid_list):
+        return self.__callapi('ReportSuite.GetKeyVisitors', rsid_list = rsid_list)
     
-    def GetListVariables(self, ):
-        return self.__callapi('ReportSuite.GetListVariables', )
+    def GetListVariables(self, rsid_list):
+        return self.__callapi('ReportSuite.GetListVariables', rsid_list = rsid_list)
     
-    def GetLocalization(self, ):
-        return self.__callapi('ReportSuite.GetLocalization', )
+    def GetLocalization(self, rsid_list):
+        return self.__callapi('ReportSuite.GetLocalization', rsid_list = rsid_list)
     
     def GetLogin(self, ):
         return self.__callapi('Permissions.GetLogin', )
@@ -153,38 +155,38 @@ class AdobeAnalytics:
     def GetLogins(self, ):
         return self.__callapi('Permissions.GetLogins', )
     
-    def GetMarketingChannelExpiration(self, ):
-        return self.__callapi('ReportSuite.GetMarketingChannelExpiration', )
+    def GetMarketingChannelExpiration(self, rsid_list):
+        return self.__callapi('ReportSuite.GetMarketingChannelExpiration', rsid_list = rsid_list)
     
-    def GetMarketingChannelRules(self, ):
-        return self.__callapi('ReportSuite.GetMarketingChannelRules', )
+    def GetMarketingChannelRules(self, rsid_list):
+        return self.__callapi('ReportSuite.GetMarketingChannelRules', rsid_list = rsid_list)
     
-    def GetMarketingChannels(self, ):
-        return self.__callapi('ReportSuite.GetMarketingChannels', )
+    def GetMarketingChannels(self, rsid_list):
+        return self.__callapi('ReportSuite.GetMarketingChannels',  rsid_list = rsid_list)
     
     def GetMetrics(self, ):
         return self.__callapi('Report.GetMetrics', )
     
-    def GetMobileAppReporting(self, ):
-        return self.__callapi('ReportSuite.GetMobileAppReporting', )
+    def GetMobileAppReporting(self, rsid_list):
+        return self.__callapi('ReportSuite.GetMobileAppReporting', rsid_list = rsid_list)
     
-    def GetPaidSearchDetection(self, ):
-        return self.__callapi('ReportSuite.GetPaidSearchDetection', )
+    def GetPaidSearchDetection(self, rsid_list):
+        return self.__callapi('ReportSuite.GetPaidSearchDetection', rsid_list = rsid_list)
     
-    def GetPrivacySettings(self, ):
-        return self.__callapi('ReportSuite.GetPrivacySettings', )
+    def GetPrivacySettings(self, rsid_list):
+        return self.__callapi('ReportSuite.GetPrivacySettings', rsid_list = rsid_list)
     
-    def GetProps(self, ):
-        return self.__callapi('ReportSuite.GetProps', )
+    def GetProps(self, rsid_list):
+        return self.__callapi('ReportSuite.GetProps', rsid_list = rsid_list)
     
-    def GetQueue(self, ):
-        return self.__callapi('Report.GetQueue', )
+    def GetQueue(self ):
+        return self.__callapi('Report.GetQueue')
     
     def GetRealTimeReport(self, ):
         return self.__callapi('Company.GetReportSuites', )
     
-    def GetRealTimeSettings(self, ):
-        return self.__callapi('ReportSuite.GetRealTimeSettings', )
+    def GetRealTimeSettings(self, rsid_list):
+        return self.__callapi('ReportSuite.GetRealTimeSettings', rsid_list = rsid_list)
     
     def GetReportDescription(self, ):
         return self.__callapi('Bookmark.GetReportDescription', )
@@ -193,36 +195,36 @@ class AdobeAnalytics:
         """Returns all report suites available to user from a given company."""
         return self.__callapi('Company.GetReportSuites')
     
-    def GetScheduledSpike(self, ):
-        return self.__callapi('ReportSuite.GetScheduledSpike', )
+    def GetScheduledSpike(self, rsid_list):
+        return self.__callapi('ReportSuite.GetScheduledSpike', rsid_list = rsid_list)
 
-    def GetSegments(self, ):
-        return self.__callapi('ReportSuite.GetSegments', )
+    def GetSegments(self, rsid_list):
+        return self.__callapi('ReportSuite.GetSegments', rsid_list = rsid_list)
     
-    def GetSiteTitle(self, ):
-        return self.__callapi('ReportSuite.GetSiteTitle', )
+    def GetSiteTitle(self, rsid_list):
+        return self.__callapi('ReportSuite.GetSiteTitle', rsid_list = rsid_list)
     
-    def GetEvents(self, ):
-        return self.__callapi('ReportSuite.GetEvents', )
+    def GetEvents(self, rsid_list):
+        return self.__callapi('ReportSuite.GetEvents', rsid_list = rsid_list)
     
-    def GetTemplate(self, ):
-        return self.__callapi('ReportSuite.GetTemplate', )
+    def GetTemplate(self, rsid_list):
+        return self.__callapi('ReportSuite.GetTemplate', rsid_list = rsid_list)
     
-    def GetTimeZone(self, ):
-        return self.__callapi('ReportSuite.GetTimeZone', )
+    def GetTimeZone(self, rsid_list):
+        return self.__callapi('ReportSuite.GetTimeZone', rsid_list = rsid_list)
     
-    def GetTrackingServer(self, ):
-        return self.__callapi('Company.GetTrackingServer', )
+    def GetTrackingServer(self, rsid_list):
+        return self.__callapi('Company.GetTrackingServer', rsid_list = rsid_list)
     
-    def GetTransactionEnabled(self, ):
-        return self.__callapi('ReportSuite.GetTransactionEnabled', )
+    def GetTransactionEnabled(self, rsid_list):
+        return self.__callapi('ReportSuite.GetTransactionEnabled', rsid_list = rsid_list)
     
-    def GetUniqueVisitorVariable(self, ):
-        return self.__callapi('ReportSuite.GetUniqueVisitorVariable', )
+    def GetUniqueVisitorVariable(self, rsid_list):
+        return self.__callapi('ReportSuite.GetUniqueVisitorVariable', rsid_list = rsid_list)
     
-    def GetVersionAccess(self, ):
+    def GetVersionAccess(self):
         return self.__callapi('Company.GetVersionAccess', )
     
-    def GetVideoSettings(self, ):
-        return self.__callapi('ReportSuite.GetVideoSettings', )
+    def GetVideoSettings(self, rsid_list):
+        return self.__callapi('ReportSuite.GetVideoSettings', rsid_list = rsid_list)
 

--- a/adobeanalytics.py
+++ b/adobeanalytics.py
@@ -58,7 +58,7 @@ class AdobeAnalytics:
     
     def GetActivation(self, rsid_list):
         """
-        Returns the activation date for the report suite(s) specified.
+        Retrieves the activation status for each of the specified report suites.
         
         Keyword arguments: 
         rsid_list -- Report suites to evaluate
@@ -66,39 +66,93 @@ class AdobeAnalytics:
         return self.__callapi('ReportSuite.GetActivation', rsid_list = rsid_list)
         
     def GetAxleStartDate(self, rsid_list):
+        """
+        Retrieves the date a report suite was migrated from SiteCatalyst 14 to axle processing (version 15).
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetAxleStartDate', rsid_list = rsid_list)
     
     def GetBaseCurrency(self, rsid_list):
+        """
+        Retrieves a list of supported currency codes for each of the specified report suites
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetBaseCurrency', rsid_list = rsid_list)
     
     def GetBaseURL(self, rsid_list):
+        """
+        Retrieves the base URL assigned to each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetBaseURL', rsid_list = rsid_list)
     
     def GetBookmarks(self, ):
         return self.__callapi('Bookmark.GetBookmarks', )
     
     def GetCalculatedMetrics(self, rsid_list):
+        """
+        Retrieves the calculated metrics assigned to each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetCalculatedMetrics', rsid_list = rsid_list)
     
     def GetClassifications(self, ):
         return self.__callapi('ReportSuite.GetClassifications', )
     
     def GetCustomCalendar(self, rsid_list):
+        """
+        Retrieves the custom calendar for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetCustomCalendar', rsid_list = rsid_list)
     
     def GetDashboards(self, ):
         return self.__callapi('Bookmark.GetDashboards', )
     
     def GetDataWarehouseDisplay(self, rsid_list):
+        """
+        Returns if data warehouse is enabled for the requested report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetDataWarehouseDisplay', rsid_list = rsid_list)
     
     def GetDefaultPage(self, rsid_list):
+        """
+        Retrieves the default page for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetDefaultPage', rsid_list = rsid_list)
     
     def GetDiscoverEnabled(self, rsid_list):
+        """
+        Returns whether ad hoc analysis (formerly Discover) is enabled for the requested report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetDiscoverEnabled', rsid_list = rsid_list)
     
     def GetEcommerce(self, rsid_list):
+        """
+        Retrieves the commerce level for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetEcommerce', rsid_list = rsid_list)
 
     def GetElements(self, ):
@@ -114,6 +168,12 @@ class AdobeAnalytics:
         return self.__callapi('Company.GetEndpoint', "GET", company = company)
     
     def GetEvars(self, rsid_list):
+        """
+        Retrieves the commerce variables for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetEvars', rsid_list = rsid_list)
     
     def GetFeed(self, ):
@@ -126,27 +186,69 @@ class AdobeAnalytics:
         return self.__callapi('CalculatedMetrics.GetFunctions', )
     
     def GetGeoSegmentation(self, rsid_list):
+        """
+        Retrieves the geography segmentation for the requested report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetGeoSegmentation', rsid_list = rsid_list)
     
     def GetGroups(self, ):
         return self.__callapi('Permissions.GetGroups', )
     
     def GetInternalURLFilters(self, rsid_list):
+        """
+        Retrieves the internal URL filters for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetInternalURLFilters', rsid_list = rsid_list)
 
     def GetIPAddressExclusions(self, rsid_list):
+        """
+        Returns a list of IP addresses excluded from website tracking for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetIPAddressExclusions', rsid_list = rsid_list)
 
     def GetIPObfuscation(self, rsid_list):
+        """
+        Retrieves the IP Address Obfuscation setting for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetIPObfuscation', rsid_list = rsid_list)
     
     def GetKeyVisitors(self, rsid_list):
+        """
+        Retrieves a list of key visitors for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetKeyVisitors', rsid_list = rsid_list)
     
     def GetListVariables(self, rsid_list):
+        """
+        Retrieves the list variables for the requested report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetListVariables', rsid_list = rsid_list)
     
     def GetLocalization(self, rsid_list):
+        """
+        Retrieves the localization (multi-byte character) settings for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetLocalization', rsid_list = rsid_list)
     
     def GetLogin(self, ):
@@ -155,28 +257,98 @@ class AdobeAnalytics:
     def GetLogins(self, ):
         return self.__callapi('Permissions.GetLogins', )
     
+    def GetMarketingChannelCosts(self, rsid_list):
+        """
+        Returns the currently defined Marketing Channel costs for the specified report suite.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
+        return self.__callapi('ReportSuite.GetMarketingChannelCosts', rsid_list = rsid_list)
+    
     def GetMarketingChannelExpiration(self, rsid_list):
+        """
+        Returns the currently defined Marketing Channel expiration dates for the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetMarketingChannelExpiration', rsid_list = rsid_list)
     
     def GetMarketingChannelRules(self, rsid_list):
+        """
+        Returns the currently defined Marketing Channel rules for the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetMarketingChannelRules', rsid_list = rsid_list)
     
     def GetMarketingChannels(self, rsid_list):
+        """
+        Returns the currently defined Marketing Channels for the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetMarketingChannels',  rsid_list = rsid_list)
     
     def GetMetrics(self, ):
         return self.__callapi('Report.GetMetrics', )
     
     def GetMobileAppReporting(self, rsid_list):
+        """
+        Retrieves the Mobile Application Tracking settings for the requested report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetMobileAppReporting', rsid_list = rsid_list)
     
     def GetPaidSearchDetection(self, rsid_list):
+        """
+        Retrieves the paid search settings for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetPaidSearchDetection', rsid_list = rsid_list)
+
+    def GetPermanentTraffic(self, rsid_list):
+        """
+        Retrieves the permanent traffic settings for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
+        return self.__callapi('ReportSuite.GetPermanentTraffic', rsid_list = rsid_list)
+        
+    def GetProcessingStatus(self, rsid_list):
+        """
+        Returns processing status for the given report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
+        return self.__callapi('ReportSuite.GetPermanentTraffic', rsid_list = rsid_list)
+    
     
     def GetPrivacySettings(self, rsid_list):
+        """
+        Returns the activation date for the report suite(s) specified.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetPrivacySettings', rsid_list = rsid_list)
     
     def GetProps(self, rsid_list):
+        """
+        Retrieves the props (traffic variables) for the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetProps', rsid_list = rsid_list)
     
     def GetQueue(self ):
@@ -186,6 +358,12 @@ class AdobeAnalytics:
         return self.__callapi('Company.GetReportSuites', )
     
     def GetRealTimeSettings(self, rsid_list):
+        """
+        Returns the metrics that are configured to provide real time data.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetRealTimeSettings', rsid_list = rsid_list)
     
     def GetReportDescription(self, ):
@@ -196,35 +374,94 @@ class AdobeAnalytics:
         return self.__callapi('Company.GetReportSuites')
     
     def GetScheduledSpike(self, rsid_list):
+        """
+        Retrieves the scheduled traffic increase settings for the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetScheduledSpike', rsid_list = rsid_list)
 
     def GetSegments(self, rsid_list):
+        """
+        Retrieves the segments that are available in one or more report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetSegments', rsid_list = rsid_list)
     
     def GetSiteTitle(self, rsid_list):
+        """
+        Retrieves the site title (friendly name) for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetSiteTitle', rsid_list = rsid_list)
     
     def GetEvents(self, rsid_list):
+        """
+        Retrieves the success events for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetEvents', rsid_list = rsid_list)
     
     def GetTemplate(self, rsid_list):
+        """
+        Retrieves the creation template for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetTemplate', rsid_list = rsid_list)
     
     def GetTimeZone(self, rsid_list):
+        """
+        Retrieves the Time Zone setting for each of the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetTimeZone', rsid_list = rsid_list)
     
     def GetTrackingServer(self, rsid_list):
+        """
+        Returns the activation date for the report suite(s) specified.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('Company.GetTrackingServer', rsid_list = rsid_list)
     
     def GetTransactionEnabled(self, rsid_list):
+        """
+        Retrieves the transaction ids storage enable for the requested report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetTransactionEnabled', rsid_list = rsid_list)
     
     def GetUniqueVisitorVariable(self, rsid_list):
+        """
+        Retrieves the unique visitor variable setting for the specified report suites.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetUniqueVisitorVariable', rsid_list = rsid_list)
     
     def GetVersionAccess(self):
         return self.__callapi('Company.GetVersionAccess', )
     
     def GetVideoSettings(self, rsid_list):
+        """
+        Retrieves video measurement settings.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
         return self.__callapi('ReportSuite.GetVideoSettings', rsid_list = rsid_list)
-

--- a/adobeanalytics.py
+++ b/adobeanalytics.py
@@ -64,46 +64,43 @@ class AdobeAnalytics:
         return self.__callapi('ReportSuite.GetActivation', rsid_list = rsid_list)
         
     def GetAxleStartDate(self):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetAxleStartDate', )
     
     def GetBaseCurrency(self, ):
-        return self.__callapi('Company.GetReportSuites', )
-    
-    def GetBaseCurrency(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetBaseCurrency', )
     
     def GetBaseURL(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetBaseURL', )
     
     def GetBookmarks(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Bookmark.GetBookmarks', )
     
     def GetCalculatedMetrics(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetCalculatedMetrics', )
     
-    def GetClassification(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+    def GetClassifications(self, ):
+        return self.__callapi('ReportSuite.GetClassifications', )
     
     def GetCustomCalendar(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetCustomCalendar', )
     
     def GetDashboards(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Bookmark.GetDashboards', )
     
     def GetDataWarehouseDisplay(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetDataWarehouseDisplay', )
     
     def GetDefaultPage(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetDefaultPage', )
     
     def GetDiscoverEnabled(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetDiscoverEnabled', )
     
     def GetEcommerce(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetEcommerce', )
 
     def GetElements(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Report.GetElements', )
       
     def GetEndpoint(self, company): 
         """ 
@@ -115,120 +112,117 @@ class AdobeAnalytics:
         return self.__callapi('Company.GetEndpoint', "GET", company = company)
     
     def GetEvars(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetEvars', )
     
     def GetFeed(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('DataFeed.GetFeed', )
     
     def GetFeeds(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('DataFeed.GetFeeds', )
     
     def GetFunctions(self, ):
-        return self.__callapi('Company.GetReportSuites', )
-    
-    def GetFunctions(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('CalculatedMetrics.GetFunctions', )
     
     def GetGeoSegmentation(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetGeoSegmentation', )
     
     def GetGroups(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Permissions.GetGroups', )
     
     def GetInternalURLFilters(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetInternalURLFilters', )
 
     def GetIPAddressExclusions(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetIPAddressExclusions', )
 
     def GetIPObfuscation(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetIPObfuscation', )
     
     def GetKeyVisitors(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetKeyVisitors', )
     
     def GetListVariables(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetListVariables', )
     
     def GetLocalization(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetLocalization', )
     
     def GetLogin(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Permissions.GetLogin', )
     
     def GetLogins(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Permissions.GetLogins', )
     
     def GetMarketingChannelExpiration(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetMarketingChannelExpiration', )
     
     def GetMarketingChannelRules(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetMarketingChannelRules', )
     
     def GetMarketingChannels(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetMarketingChannels', )
     
     def GetMetrics(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Report.GetMetrics', )
     
     def GetMobileAppReporting(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetMobileAppReporting', )
     
     def GetPaidSearchDetection(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetPaidSearchDetection', )
     
     def GetPrivacySettings(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetPrivacySettings', )
     
     def GetProps(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetProps', )
     
     def GetQueue(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Report.GetQueue', )
     
     def GetRealTimeReport(self, ):
         return self.__callapi('Company.GetReportSuites', )
     
     def GetRealTimeSettings(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetRealTimeSettings', )
     
     def GetReportDescription(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Bookmark.GetReportDescription', )
       
     def GetReportSuites(self):
         """Returns all report suites available to user from a given company."""
         return self.__callapi('Company.GetReportSuites')
     
     def GetScheduledSpike(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetScheduledSpike', )
 
     def GetSegments(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetSegments', )
     
     def GetSiteTitle(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetSiteTitle', )
     
-    def GetSuccessEvents(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+    def GetEvents(self, ):
+        return self.__callapi('ReportSuite.GetEvents', )
     
     def GetTemplate(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetTemplate', )
     
     def GetTimeZone(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetTimeZone', )
     
     def GetTrackingServer(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Company.GetTrackingServer', )
     
     def GetTransactionEnabled(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetTransactionEnabled', )
     
     def GetUniqueVisitorVariable(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetUniqueVisitorVariable', )
     
     def GetVersionAccess(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('Company.GetVersionAccess', )
     
     def GetVideoSettings(self, ):
-        return self.__callapi('Company.GetReportSuites', )
+        return self.__callapi('ReportSuite.GetVideoSettings', )
 

--- a/adobeanalytics.py
+++ b/adobeanalytics.py
@@ -5,29 +5,29 @@ Created on Sun Mar 06 00:27:21 2016
 """
 
 from datetime import date, timedelta 
-from collections import defaultdict 
 import requests, time, binascii, hashlib, json, urllib #adding hashlib 
-import pandas as pd 
-  
+import pandas as pd
+
 # Authentication 
 class AdobeAnalytics: 
   
-    def __init__(self, user_name, shared_secret, endpoint=''): 
-         """ 
-         Entry point for making authenticated API calls to the Adobe Report API's 
-         """ 
-         self.__user_name = user_name 
-         self.__shared_secret = shared_secret 
-         self.__company = self.__user_name.split(":")[1] 
+    def __init__(self, user_name, shared_secret, endpoint='', debug = False): 
+        """ 
+        Entry point for making authenticated API calls to the Adobe Report API's 
+        """ 
+        self.__user_name = user_name 
+        self.__shared_secret = shared_secret 
+        self.__company = self.__user_name.split(":")[1] 
+        self.__debug = debug
           
-         #If user doesn't specify their own endpoint, call API to get proper endpoint 
-         #Most users should never do this, but some have requested capability in RSiteCatalyst 
-         self.__api_url = 'https://api.omniture.com/admin/1.4/rest/' 
-         if endpoint != '': 
-             self.__api_url = endpoint 
-         else: 
-             self.__api_url = self.GetEndpoint(company = self.__company) 
-  
+        #If user doesn't specify their own endpoint, call API to get proper endpoint 
+        #Most users should never do this, but some have requested capability in RSiteCatalyst 
+        self.__api_url = 'https://api.omniture.com/admin/1.4/rest/' 
+        if endpoint != '': 
+            self.__api_url = endpoint 
+        else: 
+            self.__api_url = self.GetEndpoint(company = self.__company)
+
     def __buildheader(self): 
         """ 
         Returns required header for authenticating API calls. This is an internal method to be used 
@@ -42,27 +42,193 @@ class AdobeAnalytics:
         return {'X-WSSE':X_str} 
         
     #Core Method, Actually runs the JSON request     
-    def __callapi(self, endpoint, **kwargs): 
-        header = self.__buildheader() 
-        req = requests.get('%s?method=%s' % (self.__api_url, endpoint), params=json.dumps(kwargs), headers=header) 
-        return req.json() 
+    def __callapi(self, endpoint, verb = "POST", **kwargs):
+        header = self.__buildheader()
+        if verb == "GET":
+            req = requests.get('%s?method=%s' % (self.__api_url, endpoint), params=json.dumps(kwargs), headers=header)
+            if self.__debug:
+                print json.dumps(kwargs)
+        else:
+            req = requests.post('%s?method=%s' % (self.__api_url, endpoint), data=json.dumps(kwargs), headers=header)
+            if self.__debug:
+                print json.dumps(kwargs)
+        return req.json()
+    
+    def GetActivation(self, rsid_list):
+        """
+        Returns the activation date for the report suite(s) specified.
+        
+        Keyword arguments: 
+        rsid_list -- Report suites to evaluate
+        """
+        return self.__callapi('ReportSuite.GetActivation', rsid_list = rsid_list)
+        
+    def GetAxleStartDate(self):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetBaseCurrency(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetBaseCurrency(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetBaseURL(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetBookmarks(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetCalculatedMetrics(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetClassification(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetCustomCalendar(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetDashboards(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetDataWarehouseDisplay(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetDefaultPage(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetDiscoverEnabled(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetEcommerce(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+
+    def GetElements(self, ):
+        return self.__callapi('Company.GetReportSuites', )
       
-    def GetEndpoint(self, **kwargs): 
+    def GetEndpoint(self, company): 
         """ 
         Calls Company.GetEndpoint to determine the appropriate endpoint for a give company 
               
         Keyword arguments: 
         company -- Company to retrieve endpoint for 
         """ 
-        return self.__callapi('Company.GetEndpoint', **kwargs) 
-       
-    # def ReportRun(self): 
-    #     # build JSON 
-    #     values = {} 
-    #     #define endpoint 
-    #     endpoint = 'Report.Run' 
-    #     __callapi(values, endpoint) 
+        return self.__callapi('Company.GetEndpoint', "GET", company = company)
+    
+    def GetEvars(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetFeed(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetFeeds(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetFunctions(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetFunctions(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetGeoSegmentation(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetGroups(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetInternalURLFilters(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+
+    def GetIPAddressExclusions(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+
+    def GetIPObfuscation(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetKeyVisitors(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetListVariables(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetLocalization(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetLogin(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetLogins(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetMarketingChannelExpiration(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetMarketingChannelRules(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetMarketingChannels(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetMetrics(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetMobileAppReporting(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetPaidSearchDetection(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetPrivacySettings(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetProps(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetQueue(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetRealTimeReport(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetRealTimeSettings(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetReportDescription(self, ):
+        return self.__callapi('Company.GetReportSuites', )
       
-    def GetReportSuites(self, **kwargs):
+    def GetReportSuites(self):
         """Returns all report suites available to user from a given company."""
-        return self.__callapi('Company.GetReportSuites', **kwargs)
+        return self.__callapi('Company.GetReportSuites')
+    
+    def GetScheduledSpike(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+
+    def GetSegments(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetSiteTitle(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetSuccessEvents(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetTemplate(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetTimeZone(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetTrackingServer(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetTransactionEnabled(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetUniqueVisitorVariable(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetVersionAccess(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+    
+    def GetVideoSettings(self, ):
+        return self.__callapi('Company.GetReportSuites', )
+


### PR DESCRIPTION
Most calls are POST requests, so add that branch of logic to function,
make default to it doesn’t need to be specified in functions.

Every function stub SHOULD be a POST request, but verify. For easier
coding, I added a debug argument to the Class constructor, which will
print out the body of the function (which should match what the API
explorer expects)